### PR TITLE
feat(registry): optionally extend simulation report with tx calldata

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Shortcuts whose execution require to set a `minAmountOut` have it set to `1` by 
 via `--slippage=<numberAsBIPS>` (allowed values: [0, 10000]. Examples: 3 represents 0.03%, 25 represents 0.25%, 100
 represents 1%).
 
+Log the tx calldata with `--calldata` (only if simulation is successful).
+
 ### Forge
 
 Please set first:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,11 @@ export enum ShortcutExecutionMode {
 }
 
 // Forge test
+export enum ForgeTestLogFormat {
+  DEFAULT = '',
+  JSON = '--json',
+}
+
 export enum TraceItemPhase {
   DEPLOYMENT = 'Deployment',
   EXECUTION = 'Execution',

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -224,6 +224,19 @@ export function getSlippageFromArgs(args: string[]): BigNumber {
   return slippage;
 }
 
+export function getIsCalldataLoggedFromArgs(args: string[]): boolean {
+  const logCalldataIdx = args.findIndex((arg) => arg.startsWith('--calldata'));
+  let isCalldataLogged: boolean;
+  if (logCalldataIdx === -1) {
+    isCalldataLogged = false;
+  } else {
+    isCalldataLogged = true;
+    args.splice(logCalldataIdx, 1);
+  }
+
+  return isCalldataLogged;
+}
+
 export function getWalletFromArgs(args: string[]): string {
   const filteredArgs = args.slice(5);
   if (filteredArgs.length != 1) throw 'Error: Please pass wallet address';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export interface SimulationResult {
 }
 
 export type Report = {
+  weirollWallet: AddressArg;
   quote: Record<string, string>;
   dust: Record<string, string>;
   gas: string;
@@ -44,6 +45,11 @@ export type Report = {
 export interface AddressData {
   address?: AddressArg;
   label: string;
+}
+
+export interface SimulationLogConfig {
+  isReportLogged: boolean;
+  isCalldataLogged: boolean;
 }
 
 export interface SimulationRoles {


### PR DESCRIPTION
It make sense to me implement this feature with a simple CLI option (`--calldata`), which gives the chance to optionally log the tx calldata as long as the simulation succeeds. Example call:

```
pnpm simulate cartio kodiak weth-wbtc 1000000,1000 --slippage=3 --calldata
```